### PR TITLE
Sending Zero rather than false prevents NaN error.

### DIFF
--- a/lib/datatables.client.coffee
+++ b/lib/datatables.client.coffee
@@ -470,11 +470,11 @@ Template.dataTable.getCountCollection = ->
 
 # ##### getTotalCount()
 Template.dataTable.getTotalCount = ->
-  return @getCountCollection().findOne( "#{ @getSubscription() }" ).count or false
+  return @getCountCollection().findOne( "#{ @getSubscription() }" ).count or 0
 
 # ##### getFilteredCount()
 Template.dataTable.getFilteredCount = ->
-  return @getCountCollection().findOne( "#{ @getSubscription() }_filtered" ).count or false
+  return @getCountCollection().findOne( "#{ @getSubscription() }_filtered" ).count or 0
 
 # ### Cursor
 #   The reactive cursor responsible for keeping the client in sync


### PR DESCRIPTION
Sending Zero rather than false prevents NaN error in client side rendering of page counts.
