### PR TITLE
fix for issue #17

### DIFF
--- a/lib/mixins/collection.coffee
+++ b/lib/mixins/collection.coffee
@@ -42,8 +42,8 @@ DataTableMixins.Collection =
 
   # ##### getTotalCount()
   getTotalCount: ->
-    return @getCountCollection().findOne( "#{ @getSubscription() }" ).count or 0
+    return @getCountCollection().findOne( "#{ @getSubscription() }#{ @getQueryAsString() }" ).count or 0
 
   # ##### getFilteredCount()
   getFilteredCount: ->
-    return @getCountCollection().findOne( "#{ @getSubscription() }_filtered" ).count or 0
+    return @getCountCollection().findOne( "#{ @getSubscription() }#{ @getQueryAsString() }_filtered" ).count or 0

--- a/lib/mixins/publish.coffee
+++ b/lib/mixins/publish.coffee
@@ -28,6 +28,7 @@ DataTableMixins.Publish =
       console.log options
       clientCollectionName = options.collectionName
       options = _.omit options, 'collectionName'
+      subscription_id = subscription + EJSON.stringify(baseQuery)
       DataTable.log "#{ subscription }:#{ clientCollectionName }:query:base", baseQuery
       DataTable.log "#{ subscription }:#{ clientCollectionName }:query:filtered", filteredQuery
       DataTable.log "#{ subscription }:#{ clientCollectionName }:options", options
@@ -44,11 +45,11 @@ DataTableMixins.Publish =
           DataTable.log "#{ subscription }:count:filtered", filtered
           # `added` is a flag that is set to true on the initial insert into the DaTableCount collection from this subscription.
           if added
-            self.added( DataTable.countCollection, subscription, { count: total } )
-            self.added( DataTable.countCollection, "#{ subscription }_filtered", { count: filtered } )
+            self.added( DataTable.countCollection, subscription_id, { count: total } )
+            self.added( DataTable.countCollection, "#{ subscription_id }_filtered", { count: filtered } )
           else
-            self.changed( DataTable.countCollection, subscription, { count: total } )
-            self.changed( DataTable.countCollection, "#{ subscription }_filtered", { count: filtered } )
+            self.changed( DataTable.countCollection, subscription_id, { count: total } )
+            self.changed( DataTable.countCollection, "#{ subscription_id }_filtered", { count: filtered } )
 
       # ###### observe
       # DataTable observes just the filtered and paginated subset of the Collection. This is for performance reasons as

--- a/lib/mixins/query.coffee
+++ b/lib/mixins/query.coffee
@@ -17,3 +17,7 @@ DataTableMixins.Query =
   # ##### getQuery()
   getQuery: ->
     return @getData().query or false
+
+  getQueryAsString: ->
+    query = @getData().query
+    if query is false then "" else EJSON.stringify @getData().query

--- a/lib/mixins/subscription.coffee
+++ b/lib/mixins/subscription.coffee
@@ -36,7 +36,7 @@ DataTableMixins.Subscription =
     autorun = Deps.autorun =>
       if @getSubscriptionHandle() and @getSubscriptionHandle().ready()
         @log 'fnServerdData:handle:ready', @getSubscriptionHandle().ready()
-        cursorOptions = skip: 0
+        cursorOptions = skip: @getTableState().iDisplayStart or 0
         cursorOptions.limit = @getTableState().iDisplayLength or 10
         if @getTableState().sort
           cursorOptions.sort = @getTableState().sort


### PR DESCRIPTION
I figured out why this is happening.  It is because there is only a single count established for each publication and it doesn't get updated for new datatables using the same collection that subscribe to it. Here is a possible solution for tracking unique counters for each subscription. Tying it to the base_query seemed like a good solution to me for keeping to total number of tracked counters to a minimum.
